### PR TITLE
adds keys_of to hash class

### DIFF
--- a/lib/keys_of_hash.rb
+++ b/lib/keys_of_hash.rb
@@ -1,5 +1,6 @@
+require 'pry'
 class Hash
-  def keys_of(arguments)
-    # code goes here
+  def keys_of(*arguments)
+    self.select {|elem, value| arguments.include? value }.keys
   end
 end


### PR DESCRIPTION
What's the correct way to style a method call on a block like this? 

it looked funny putting .keys on the end of "end"

```
 self.select do |elem, value|
      arguments.include? value
 end.keys
```